### PR TITLE
Add a templated repolist.txt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
+    <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
 
     <docker.source.dir>${basedir}/src/main/docker</docker.source.dir>
 
@@ -87,6 +88,23 @@
     <junit.version>4.12</junit.version>
     <fabric8.version>3.0.12</fabric8.version>
     <fabric8.release.version>${fabric8.version}</fabric8.release.version>
+
+    <quickstarts.url.base>https://github.com/fabric8-quickstarts</quickstarts.url.base>
+    <karaf-camel-amq.version>karaf-camel-amq-1.0.0.fuse-750023</karaf-camel-amq.version>
+    <karaf-camel-log.version>karaf-camel-log-1.0.0.fuse-750023</karaf-camel-log.version>
+    <karaf-camel-rest-sql.version>karaf-camel-rest-sql-1.0.0.fuse-750023</karaf-camel-rest-sql.version>
+    <karaf-cxf-rest.version>karaf-cxf-rest-1.0.0.fuse-750023</karaf-cxf-rest.version>
+    <spring-boot-camel.version>spring-boot-camel-1.0.0.fuse-750023</spring-boot-camel.version>
+    <spring-boot-camel-amq.version>spring-boot-camel-amq-1.0.0.fuse-750022</spring-boot-camel-amq.version>
+    <spring-boot-camel-config.version>spring-boot-camel-config-1.0.0.fuse-750022</spring-boot-camel-config.version>
+    <spring-boot-camel-drools.version>spring-boot-camel-drools-1.0.0.fuse-750019</spring-boot-camel-drools.version>
+    <spring-boot-camel-infinispan.version>spring-boot-camel-infinispan-1.0.0.fuse-750020</spring-boot-camel-infinispan.version>
+    <spring-boot-camel-rest-sql.version>spring-boot-camel-rest-sql-1.0.0.fuse-750019</spring-boot-camel-rest-sql.version>
+    <spring-boot-camel-rest-3scale.version>spring-boot-camel-rest-3scale-1.0.0.fuse-750019</spring-boot-camel-rest-3scale.version>
+    <spring-boot-camel-xml.version>spring-boot-camel-xml-1.0.0.fuse-750019</spring-boot-camel-xml.version>
+    <spring-boot-cxf-jaxrs.version>spring-boot-cxf-jaxrs-1.0.0.fuse-750019</spring-boot-cxf-jaxrs.version>
+    <spring-boot-cxf-jaxws.version>spring-boot-cxf-jaxws-1.0.0.fuse-750019</spring-boot-cxf-jaxws.version>
+
     <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
 
     <!-- build with -Dquickstart.git.repos=path/to/repos.properties to configure a list of repos
@@ -162,6 +180,28 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${maven.resources.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/extra-resources/</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>

--- a/src/main/resources/repolist.txt
+++ b/src/main/resources/repolist.txt
@@ -1,0 +1,14 @@
+karaf-camel-amq=${quickstarts.url.base}/karaf-camel-amq.git|${karaf-camel-amq.version}
+karaf-camel-log=${quickstarts.url.base}/karaf-camel-log.git|${karaf-camel-log.version}
+karaf-camel-rest-sql=${quickstarts.url.base}/karaf-camel-rest-sql.git|${karaf-camel-rest-sql.version}
+karaf-cxf-rest=${quickstarts.url.base}/karaf-cxf-rest.git|${karaf-cxf-rest.version}
+spring-boot-camel=${quickstarts.url.base}/spring-boot-camel.git|${spring-boot-camel.version}
+spring-boot-camel-amq=${quickstarts.url.base}/spring-boot-camel-amq.git|${spring-boot-camel-amq.version}
+spring-boot-camel-config=${quickstarts.url.base}/spring-boot-camel-config.git|${spring-boot-camel-config.version}
+spring-boot-camel-drools=${quickstarts.url.base}/spring-boot-camel-drools.git|${spring-boot-camel-drools.version}
+spring-boot-camel-infinispan=${quickstarts.url.base}/spring-boot-camel-infinispan.git|${spring-boot-camel-infinispan.version}
+spring-boot-camel-rest-sql=${quickstarts.url.base}/spring-boot-camel-rest-sql.git|${spring-boot-camel-rest-sql.version}
+spring-boot-camel-rest-3scale=${quickstarts.url.base}/spring-boot-camel-rest-3scale.git|${spring-boot-camel-rest-3scale.version}
+spring-boot-camel-xml=${quickstarts.url.base}/spring-boot-camel-xml.git|${spring-boot-camel-xml.version}
+spring-boot-cxf-jaxrs=${quickstarts.url.base}/spring-boot-cxf-jaxrs.git|${spring-boot-cxf-jaxrs.version}
+spring-boot-cxf-jaxws=${quickstarts.url.base}/spring-boot-cxf-jaxws.git|${spring-boot-cxf-jaxws.version}


### PR DESCRIPTION
--- **This PR is for discussion, there needs to be `<dependency/>` entries added to make it work in a PNC context**

I think I found an easier way to generate the repolist.txt off of the build.    If we include the properties for the quickstarts, and template the repolist.txt, we can generate at build time.

The great thing here is that if we add a `<dependency/>` for each one of those quickstarts, PNC will do the work for us.    For 7.6, I've added the quickstarts to build in PNC, which gives us versions generated by PNC.    If we add a `<dependency/>` for each one of those, then we can get PME to do all the version replacements we want here and generate the repolist.txt correctly.

The fabric8/f-m-p/redhat-fuse version replacement done in the hack-quickstarts will be done by PME.

The one thing I am unsure of is how the quickstart redhat-00001 tags get pushed to fabric8-quickstarts/<quickstart-name>.      If it isn't already being done, it should be pretty easy to do that off of the repolist.txt.   

I *think* this eliminates the need for hack-quickstarts.    Am I missing anything?
