### PR TITLE
The spring-boot-camel-soap-rest-bridge quickstart contains two differ…

### DIFF
--- a/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
+++ b/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
@@ -330,7 +330,7 @@ public class ArchetypeBuilder extends AbstractBuilder{
         }
 
         if (testSrcDir != null) {
-            File rootPackage = archetypeUtils.findRootPackage(testSrcDir);
+            File rootPackage = archetypeUtils.findRootTestPackage(testSrcDir);
 
             if (rootPackage != null) {
                 String packagePath = archetypeUtils.relativePath(testSrcDir, rootPackage);


### PR DESCRIPTION
The spring-boot-camel-soap-rest-bridge quickstart contains two different packages in src/test/java.    ipaas-quickstarts isn't prepared for that situation and it breaks the ability to create the archetype.